### PR TITLE
Add syntaxhighlight-tag

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -40,7 +40,8 @@
 			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataCite",
 			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataQuiz",
 			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataEmbedVideo",
-			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataDynamicPageList"
+			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataDynamicPageList",
+			"BlueSpiceDistributionHooks::onBSInsertMagicAjaxGetDataSyntaxHighlight"
 		]
 	},
 	"manifest_version": 1

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -10,12 +10,12 @@
 	"bs-distribution-tag-quiz-desc": "Fügt einem Artikel einfache quizartige Fragen inklusive vorgegebener Auswertung hinzu.",
 	"bs-distribution-tag-embedvideo-desc": "Bettet Video-Clips von populären Video-Sharing-Diensten ein.",
 	"bs-distribution-tag-dynamicpagelist-desc": "Erzeugt eine dynamische Liste von Seiten basierend auf verschiedenen Parametern.",
-	"bs-distribution-tag-syntaxhighlight-desc": "Ergänz das Tag CSyntaxHighlight, das zur Anzeige formatierter Codeschnipsel verwendet wird.",
+	"bs-distribution-tag-syntaxhighlight-desc": "Ergänzt das Tag CSyntaxHighlight, das zur Anzeige formatierter Codeschnipsel verwendet wird.",
 	"bs-distribution-tag-syntaxhighlight-example-1": "Auswahl der Sprache",
 	"bs-distribution-tag-syntaxhighlight-example-2": "Mögliche Anzahl an Zeilen",
 	"bs-distribution-tag-syntaxhighlight-example-3": "Nummer der ersten Zeile",
 	"bs-distribution-tag-syntaxhighlight-example-4": "Hervorgehobene Zeilen",
-	"bs-distribution-tag-syntaxhighlight-example-5": "Quelltext als Teil innerhalb eines Paragrafs",
+	"bs-distribution-tag-syntaxhighlight-example-5": "Quelltext als Teil innerhalb eines Absatzes",
 	"bs-distribution-tag-syntaxhighlight-example-6": "Klassen definieren",
 	"bs-distribution-tag-syntaxhighlight-example-7": "CSS einbinden"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -9,5 +9,13 @@
 	"bs-distribution-tag-references-desc": "Zeigt den Text aller durch 'ref' Tags markierten Stellen bis zu diesem Punkt der Seite an.",
 	"bs-distribution-tag-quiz-desc": "Fügt einem Artikel einfache quizartige Fragen inklusive vorgegebener Auswertung hinzu.",
 	"bs-distribution-tag-embedvideo-desc": "Bettet Video-Clips von populären Video-Sharing-Diensten ein.",
-	"bs-distribution-tag-dynamicpagelist-desc": "Erzeugt eine dynamische Liste von Seiten basierend auf verschiedenen Parametern."
+	"bs-distribution-tag-dynamicpagelist-desc": "Erzeugt eine dynamische Liste von Seiten basierend auf verschiedenen Parametern.",
+	"bs-distribution-tag-syntaxhighlight-desc": "Ergänz das Tag CSyntaxHighlight, das zur Anzeige formatierter Codeschnipsel verwendet wird.",
+	"bs-distribution-tag-syntaxhighlight-example-1": "Auswahl der Sprache",
+	"bs-distribution-tag-syntaxhighlight-example-2": "Mögliche Anzahl an Zeilen",
+	"bs-distribution-tag-syntaxhighlight-example-3": "Nummer der ersten Zeile",
+	"bs-distribution-tag-syntaxhighlight-example-4": "Hervorgehobene Zeilen",
+	"bs-distribution-tag-syntaxhighlight-example-5": "Quelltext als Teil innerhalb eines Paragrafs",
+	"bs-distribution-tag-syntaxhighlight-example-6": "Klassen definieren",
+	"bs-distribution-tag-syntaxhighlight-example-7": "CSS einbinden"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,5 +9,13 @@
 	"bs-distribution-tag-references-desc": "Displays the list of footnotes which were inserted into the articles.",
 	"bs-distribution-tag-quiz-desc": "Adds simple quiz questions to an article.",
 	"bs-distribution-tag-embedvideo-desc": "Embeds video clips from popular sharing platforms.",
-	"bs-distribution-tag-dynamicpagelist-desc": "Generates a dynamic list of articles based on various parameters."
+	"bs-distribution-tag-dynamicpagelist-desc": "Generates a dynamic list of articles based on various parameters.",
+	"bs-distribution-tag-syntaxhighlight-desc": "Inserts CSyntaxHighlight tag, used to display formatted code snippets.",
+	"bs-distribution-tag-syntaxhighlight-example-1": "Selection of language",
+	"bs-distribution-tag-syntaxhighlight-example-2": "Enabled numbers of line",
+	"bs-distribution-tag-syntaxhighlight-example-3": "Number of first line",
+	"bs-distribution-tag-syntaxhighlight-example-4": "Highlighted lines",
+	"bs-distribution-tag-syntaxhighlight-example-5": "Source code inline as part of a paragraph",
+	"bs-distribution-tag-syntaxhighlight-example-6": "Define class",
+	"bs-distribution-tag-syntaxhighlight-example-7": "Include CSS"
 }

--- a/includes/BlueSpiceDistributionHooks.php
+++ b/includes/BlueSpiceDistributionHooks.php
@@ -209,6 +209,57 @@ It is very useful to use footnotes <ref>A note can provide an author's comments 
 	}
 
 	/**
+	 * Inject Syntaxhighlight tag into InsertMagic
+	 * @param Object $oResponse reference
+	 * $param String $type
+	 * @return always true to keep hook running
+	 */
+	public static function onBSInsertMagicAjaxGetDataSyntaxHighlight( &$oResponse, $type ) {
+		if ( $type != 'tags' ) return true;
+
+		$oResponse->result[] = array(
+			'id' => 'syntaxhighlight',
+			'type' => 'tag',
+			'name' => 'syntaxhighlight',
+			'desc' => wfMessage( 'bs-distribution-tag-syntaxhighlight-desc' )->plain(),
+			'code' => '<syntaxhighlight></syntaxhighlight>',
+			'examples' => array(
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-1' )->escaped(),
+                                        'code' => '<syntaxhighlight lang="{lang}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-2' )->escaped(),
+                                        'code' => '<syntaxhighlight line="{line}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-3' )->escaped(),
+                                        'code' => '<syntaxhighlight start="{start}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-4' )->escaped(),
+                                        'code' => '<syntaxhighlight highlight="{highlight}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-5' )->escaped(),
+                                        'code' => '<syntaxhighlight inline="{inline}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-6' )->escaped(),
+                                        'code' => '<syntaxhighlight class="{class}"></syntaxhighlight>'
+                                ),
+                                array(
+                                        'label' => wfMessage( 'bs-distribution-tag-syntaxhighlight-example-7' )->escaped(),
+                                        'code' => '<syntaxhighlight style="{style}"></syntaxhighlight>'
+                                )
+			),
+			'helplink' => 'https://help.bluespice.com/index.php/CSyntaxHighlight'
+		);
+
+		return true;
+	}
+
+	/**
 	 * @param BaseTemplate $baseTemplate
 	 * @param array $toolbox
 	 * @return boolean


### PR DESCRIPTION
Added syntaxhighlight-tag to DistributionConnector as replacement for the <source>-Tag.

Related to ERM7852.