### PR TITLE
Refactor BlueSpiceDistributionConnecter

### DIFF
--- a/DistributionConnector.class.php
+++ b/DistributionConnector.class.php
@@ -1,5 +1,0 @@
-<?php
-
-class DistributionConnector extends BsExtensionMW {
-	
-}

--- a/extension.json
+++ b/extension.json
@@ -12,7 +12,7 @@
 		"BlueSpiceFoundation": {
 			"Extensions": {
 				"BlueSpiceDistributionConnector": {
-					"className": "DistributionConnector",
+					"className": "\\BlueSpice\\DistributionConnector\\Extension",
 					"extPath": "/BlueSpiceDistributionConnector"
 				}
 			},
@@ -70,8 +70,10 @@
 			"i18n"
 		]
 	},
+	"AutoloadNamespaces": {
+		"BlueSpice\\DistributionConnector\\" : "src/"
+	},
 	"AutoloadClasses": {
-		"DistributionConnector": "DistributionConnector.class.php",
 		"BlueSpiceDistributionHooks": "includes/BlueSpiceDistributionHooks.php",
 		"BSUserLoginMobileTemplate": "includes/skins/BSUserLoginMobileTemplate.php"
 	},

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BlueSpice\DistributionConnector;
+
+class Extension extends \BlueSpice\Extension {
+
+}


### PR DESCRIPTION
Moved class to src/Extension.php
todo:
the extension might still be included in the pre-1.25 way in /settings.d
with 'equire_once [snip] BlueSpiceDistributionConnector.php";

When /settings.d/ is fixed, BlueSpiceDistributionConnector.php can be
deleted