### PR TITLE
Fix toolbox handling when duplicator is not active

### DIFF
--- a/includes/BlueSpiceDistributionHooks.php
+++ b/includes/BlueSpiceDistributionHooks.php
@@ -215,6 +215,11 @@ It is very useful to use footnotes <ref>A note can provide an author's comments 
 	public static function onBaseTemplateToolbox( BaseTemplate $baseTemplate, array &$toolbox ) {
 		global $wgHooks;
 
+		// Hook might not be set. If this is the case, skip the rest of the function
+		if ( !isset( $wgHooks['SkinTemplateToolboxEnd'] ) ) {
+			return true;
+		}
+
 		//Move duplicater toolbox link from legacy hook to
 		//SkinTemplateToolboxEnd
 		$iPosDuplicatior = array_search(


### PR DESCRIPTION
In this case, the legacy hook SkinTemplateToolboxEnd is not set.
This led to a fatal and is resolved by simply skipping the treatment
of the hook.